### PR TITLE
rename all references to stack with service

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,8 +13,8 @@
             "allow": [],
             "depConstraints": [
               {
-                "sourceTag": "stack",
-                "onlyDependOnLibsWithTags": ["stack", "lib"]
+                "sourceTag": "service",
+                "onlyDependOnLibsWithTags": ["service", "lib"]
               },
               {
                 "sourceTag": "lib",

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Generate service
-        run: yarn nx workspace-generator service test-stack
+        run: yarn nx workspace-generator service test-service
 
       - name: Generate library
         run: yarn nx g @nrwl/node:lib test-lib --tags lib

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A template for a Serverless Framework microservices architecture based on the [n
 ## Whats Included
 
 - A template project layout using latest version of Nx and Servrless Framework
-- An easy to use workspace generator to generate a template/stack with Serverless Framework files and related Nx configuration
+- An easy to use workspace generator to generate a template/service with Serverless Framework files and related Nx configuration
 - Configured with a basic AWS provider that can be easily adopted to any cloud provider
 - Serverless Offline microservices architecture support
 

--- a/services/background-jobs/project.json
+++ b/services/background-jobs/project.json
@@ -50,5 +50,5 @@
       }
     }
   },
-  "tags": ["stack"]
+  "tags": ["service"]
 }

--- a/services/public-api/project.json
+++ b/services/public-api/project.json
@@ -70,5 +70,5 @@
       }
     }
   },
-  "tags": ["stack"]
+  "tags": ["service"]
 }

--- a/tools/generators/service/workspace-config.ts
+++ b/tools/generators/service/workspace-config.ts
@@ -12,32 +12,32 @@ const buildRunCommandConfig = (dir: string, command: string) => ({
 export const addWorkspaceConfig = (
   host: Tree,
   projectName: string,
-  stackRoot: string
+  serviceRoot: string
 ) => {
   addProjectConfiguration(host, projectName, {
-    root: stackRoot,
+    root: serviceRoot,
     projectType: 'application',
-    sourceRoot: stackRoot + '/src',
+    sourceRoot: serviceRoot + '/src',
     targets: {
       build: {
-        ...buildRunCommandConfig(stackRoot, 'sls package'),
+        ...buildRunCommandConfig(serviceRoot, 'sls package'),
       },
       serve: {
-        ...buildRunCommandConfig(stackRoot, 'sls offline start'),
+        ...buildRunCommandConfig(serviceRoot, 'sls offline start'),
       },
       deploy: {
-        ...buildRunCommandConfig(stackRoot, 'sls deploy'),
+        ...buildRunCommandConfig(serviceRoot, 'sls deploy'),
       },
       remove: {
-        ...buildRunCommandConfig(stackRoot, 'sls remove'),
+        ...buildRunCommandConfig(serviceRoot, 'sls remove'),
       },
       lint: {
         executor: '@nrwl/linter:eslint',
         options: {
-          lintFilePatterns: [stackRoot + '/**/*.ts'],
+          lintFilePatterns: [serviceRoot + '/**/*.ts'],
         },
       },
     },
-    tags: ['stack'],
+    tags: ['service'],
   });
 };


### PR DESCRIPTION
The upstream version of this template referred to services as stacks and as such, all the generators and related code were built as such. I had partially renamed elements to service and missed some key instances. This should finish the rename of stack to service.