### PR TITLE
Add analyzer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ nx g @nrwl/node:lib <LIBRARY_NAME>
   nx run-many --target=test --all --stage=<STAGE_NAME>
   ```
 
+**Analyze function bundles**
+
+When building serverless applications, it's important to understand your memory footprint due to Lambda's memory settings as you can experience unexpected errors. As such, the following script can be used to understand the memory footprint of your individual functions:
+
+```shell
+yarn analyze <SERVICE_NAME> --function=<FUNCTION_NAME>
+```
+
+This will open the results in a new tab in your browser with the results using [esbuild visualizer](https://www.npmjs.com/package/esbuild-visualizer).
+
 **Run offline / locally**
 
 - To run a single service

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "nx build",
     "deploy": "nx deploy",
     "undeploy": "nx remove",
+    "analyze": "nx analyze",
     "serve": "nx serve",
     "test": "nx test",
     "lint": "nx workspace-lint && nx lint",

--- a/services/background-jobs/project.json
+++ b/services/background-jobs/project.json
@@ -35,6 +35,14 @@
         "command": "sls remove"
       }
     },
+    "analyze": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "services/background-jobs",
+        "color": true,
+        "command": "sls package --analyze {args.function}"
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {

--- a/services/public-api/project.json
+++ b/services/public-api/project.json
@@ -41,6 +41,14 @@
         "command": "sls remove"
       }
     },
+    "analyze": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "cwd": "services/public-api",
+        "color": true,
+        "command": "sls package --analyze {args.function}"
+      }
+    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {

--- a/tools/generators/service/workspace-config.ts
+++ b/tools/generators/service/workspace-config.ts
@@ -31,6 +31,12 @@ export const addWorkspaceConfig = (
       remove: {
         ...buildRunCommandConfig(serviceRoot, 'sls remove'),
       },
+      analyze: {
+        ...buildRunCommandConfig(
+          serviceRoot,
+          'sls package --analyze {args.function}'
+        ),
+      },
       lint: {
         executor: '@nrwl/linter:eslint',
         options: {


### PR DESCRIPTION
Closes #5 

Adds scripts to run the `serverless-analyze-bundle-plugin` and investigate function bundle sizes. Displays results via `esbuild-visualizer`. Some examples from testing:

`yarn analyze public-api --function=healthcheck`
<img width="1440" alt="Screen Shot 2022-02-28 at 12 50 38 PM" src="https://user-images.githubusercontent.com/1815379/156042643-f7e912d9-e044-4f04-bbe0-64e9a25cd1e9.png">

`yarn analyze public-api --function=graphql`
<img width="1437" alt="Screen Shot 2022-02-28 at 12 51 30 PM" src="https://user-images.githubusercontent.com/1815379/156042652-889e524f-07a3-42e5-a0a7-ef29deb088d1.png">
