### PR TITLE
add interactive developer console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+.node_repl_history
 
 # System Files
 .DS_Store

--- a/libs/shared/console.js
+++ b/libs/shared/console.js
@@ -1,21 +1,35 @@
-// const fs = require('fs');
+const fs = require('fs');
 const path = require('path');
 const repl = require('repl');
-const shared = require(path.join(__dirname, 'src'));
+
+function getAllFiles(dirPath, arrayOfFiles = []) {
+  const files = fs.readdirSync(dirPath);
+
+  files.forEach((file) => {
+    if (file === 'index.ts' || file.includes('test.ts')) {
+      return;
+    }
+
+    if (fs.statSync(dirPath + '/' + file).isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + '/' + file, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(path.join(__dirname, dirPath, '/', file));
+    }
+  });
+
+  return arrayOfFiles;
+}
 
 const loadFunctions = (context) => {
   Object.keys(require.cache).forEach((key) => {
     delete require.cache[key];
   });
 
-  Object.entries(shared).forEach(([key, value]) => {
-    context[key] = value;
+  const allFilePaths = getAllFiles('./src');
+  allFilePaths.forEach((filePath) => {
+    const fileName = filePath.split('/').pop().slice(0, -3);
+    context[fileName] = require(filePath);
   });
-
-  // fs.readdirSync(modelDir, 'utf8').forEach((name) => {
-  //   const filePath = path.join(modelDir, name);
-  //   context[name.slice(0, -3)] = require(filePath);
-  // });
 };
 
 const replServer = repl.start('app > ');

--- a/libs/shared/console.js
+++ b/libs/shared/console.js
@@ -1,0 +1,34 @@
+// const fs = require('fs');
+const path = require('path');
+const repl = require('repl');
+const shared = require(path.join(__dirname, 'src'));
+
+const loadFunctions = (context) => {
+  Object.keys(require.cache).forEach((key) => {
+    delete require.cache[key];
+  });
+
+  Object.entries(shared).forEach(([key, value]) => {
+    context[key] = value;
+  });
+
+  // fs.readdirSync(modelDir, 'utf8').forEach((name) => {
+  //   const filePath = path.join(modelDir, name);
+  //   context[name.slice(0, -3)] = require(filePath);
+  // });
+};
+
+const replServer = repl.start('app > ');
+replServer.setupHistory('./.node_repl_history', (err) => {
+  console.error(err);
+});
+loadFunctions(replServer.context);
+
+replServer.defineCommand('re', {
+  help: 'Reload the models without resetting the environment',
+  action() {
+    loadFunctions(replServer.context);
+    console.log('reloaded!');
+    this.displayPrompt();
+  },
+});

--- a/libs/shared/project.json
+++ b/libs/shared/project.json
@@ -17,6 +17,14 @@
         "jestConfig": "libs/shared/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "console": {
+      "executor": "./tools/executors/workspace:run-command",
+      "options": {
+        "cwd": "libs/shared",
+        "color": true,
+        "command": "node --experimental-repl-await -r ts-node/register ./console.js"
+      }
     }
   },
   "tags": []

--- a/libs/shared/src/utils/lambda/invoke.ts
+++ b/libs/shared/src/utils/lambda/invoke.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs';
 const yaml = require('js-yaml');
 
 const serverlessCommon = yaml.load(
-  readFileSync('../../serverless.common.yml', 'utf8')
+  readFileSync(__dirname + '/../../../../../serverless.common.yml', 'utf8')
 );
 const PORTS = Object.entries(serverlessCommon.custom.ports).reduce(
   (acc, [serviceName, servicePorts]) => {

--- a/libs/shared/src/utils/lambda/invoke.ts
+++ b/libs/shared/src/utils/lambda/invoke.ts
@@ -10,7 +10,7 @@ import { readFileSync } from 'fs';
 const yaml = require('js-yaml');
 
 const serverlessCommon = yaml.load(
-  readFileSync('./serverless.common.yml', 'utf8')
+  readFileSync('../../serverless.common.yml', 'utf8')
 );
 const PORTS = Object.entries(serverlessCommon.custom.ports).reduce(
   (acc, [serviceName, servicePorts]) => {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "dep-graph": "nx dep-graph",
     "help": "nx help",
     "prepare": "husky install",
-    "codegen": "nx codegen"
+    "codegen": "nx codegen",
+    "console": "nx console"
   },
   "dependencies": {
     "@graphql-tools/merge": "^8.2.3",
@@ -71,6 +72,7 @@
     "esbuild-visualizer": "^0.3.1",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.4.0",
+    "execa": "5.1.1",
     "graphql-schema-linter": "^2.0.1",
     "husky": "^7.0.4",
     "jest": "^27.5.1",
@@ -84,6 +86,7 @@
     "serverless-s3-remover": "^0.6.0",
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
+    "ts-node": "^10.5.0",
     "typescript": "^4.5.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "esbuild-visualizer": "^0.3.1",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.4.0",
-    "execa": "5.1.1",
     "graphql-schema-linter": "^2.0.1",
     "husky": "^7.0.4",
     "jest": "^27.5.1",

--- a/services/background-jobs/project.json
+++ b/services/background-jobs/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "services/background-jobs/src",
   "targets": {
     "build": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
@@ -12,7 +12,7 @@
       }
     },
     "serve": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
@@ -20,7 +20,7 @@
       }
     },
     "deploy": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
@@ -28,7 +28,7 @@
       }
     },
     "remove": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
@@ -36,7 +36,7 @@
       }
     },
     "analyze": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/background-jobs",
         "color": true,
@@ -55,6 +55,14 @@
       "options": {
         "jestConfig": "services/background-jobs/jest.config.js",
         "passWithNoTests": true
+      }
+    },
+    "console": {
+      "executor": "./tools/executors/workspace:run-command",
+      "options": {
+        "cwd": "services/public-api",
+        "color": true,
+        "command": "node --experimental-repl-await ./console.js"
       }
     }
   },

--- a/services/public-api/console.js
+++ b/services/public-api/console.js
@@ -1,30 +1,51 @@
-// const fs = require('fs');
-// const path = require('path');
 const repl = require('repl');
+let functionsMap = {};
 
-console.log(__dirname);
-// const modelDir = path.join(__dirname, 'src', 'models');
+try {
+  functionsMap = require('./src');
+} catch (err) {
+  console.log(
+    'No src/index found. Using default node repl without any context injected.'
+  );
+}
 
-// const loadModels = (context) => {
-//   Object.keys(require.cache).forEach((key) => {
-//     delete require.cache[key];
-//   });
-//   fs.readdirSync(modelDir, 'utf8').forEach((name) => {
-//     const filePath = path.join(modelDir, name);
-//     context[name.slice(0, -3)] = require(filePath);
-//   });
-// };
+const replServer = repl.start({
+  prompt: 'app > ',
+  useColors: true,
+});
 
-const replServer = repl.start('app >');
 replServer.setupHistory('./.node_repl_history', (err) => {
   console.error(err);
 });
-// loadModels(replServer.context);
+
+Object.entries(functionsMap).forEach(([key, value]) => {
+  replServer.context[key] = value;
+});
 
 replServer.defineCommand('re', {
   help: 'Reload the models without resetting the environment',
   action() {
-    // loadModels(replServer.context);
+    // bust require cache
+    Object.keys(require.cache).forEach((key) => {
+      delete require.cache[key];
+    });
+
+    // fetch map of functions to reload
+    try {
+      functionsMap = require('./src');
+    } catch (err) {
+      console.log(
+        'No src/index found. Using default node repl without any context injected.'
+      );
+    }
+    Object.entries(functionsMap).forEach(([key, value]) => {
+      replServer.context[key] = value;
+    });
+
+    // inform user that reload is complete
+    console.log('reloaded!');
+
+    // reset the prompt
     this.displayPrompt();
   },
 });

--- a/services/public-api/console.js
+++ b/services/public-api/console.js
@@ -2,7 +2,7 @@
 // const path = require('path');
 const repl = require('repl');
 
-console.log(__dirname``);
+console.log(__dirname);
 // const modelDir = path.join(__dirname, 'src', 'models');
 
 // const loadModels = (context) => {

--- a/services/public-api/console.js
+++ b/services/public-api/console.js
@@ -1,0 +1,30 @@
+// const fs = require('fs');
+// const path = require('path');
+const repl = require('repl');
+
+console.log(__dirname``);
+// const modelDir = path.join(__dirname, 'src', 'models');
+
+// const loadModels = (context) => {
+//   Object.keys(require.cache).forEach((key) => {
+//     delete require.cache[key];
+//   });
+//   fs.readdirSync(modelDir, 'utf8').forEach((name) => {
+//     const filePath = path.join(modelDir, name);
+//     context[name.slice(0, -3)] = require(filePath);
+//   });
+// };
+
+const replServer = repl.start('app >');
+replServer.setupHistory('./.node_repl_history', (err) => {
+  console.error(err);
+});
+// loadModels(replServer.context);
+
+replServer.defineCommand('re', {
+  help: 'Reload the models without resetting the environment',
+  action() {
+    // loadModels(replServer.context);
+    this.displayPrompt();
+  },
+});

--- a/services/public-api/project.json
+++ b/services/public-api/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "services/public-api/src",
   "targets": {
     "build": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/public-api",
         "color": true,
@@ -12,7 +12,7 @@
       }
     },
     "serve": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/public-api",
         "color": true,
@@ -26,7 +26,7 @@
       ]
     },
     "deploy": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/public-api",
         "color": true,
@@ -34,7 +34,7 @@
       }
     },
     "remove": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/public-api",
         "color": true,
@@ -42,7 +42,7 @@
       }
     },
     "analyze": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/public-api",
         "color": true,
@@ -70,11 +70,19 @@
       ]
     },
     "codegen": {
-      "executor": "@nrwl/workspace:run-commands",
+      "executor": "./tools/executors/workspace:run-command",
       "options": {
         "cwd": "services/public-api",
         "color": true,
         "command": "graphql-codegen; yarn format"
+      }
+    },
+    "console": {
+      "executor": "./tools/executors/workspace:run-command",
+      "options": {
+        "cwd": "services/public-api",
+        "color": true,
+        "command": "node --experimental-repl-await ./console.js"
       }
     }
   },

--- a/tools/executors/workspace/executor.json
+++ b/tools/executors/workspace/executor.json
@@ -1,0 +1,9 @@
+{
+  "executors": {
+    "run-command": {
+      "implementation": "./impl",
+      "schema": "./schema.json",
+      "description": "Runs a command without capturing stdin/stdout/stderr"
+    }
+  }
+}

--- a/tools/executors/workspace/impl.js
+++ b/tools/executors/workspace/impl.js
@@ -1,4 +1,19 @@
 'use strict';
+var __assign =
+  (this && this.__assign) ||
+  function () {
+    __assign =
+      Object.assign ||
+      function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
 var __awaiter =
   (this && this.__awaiter) ||
   function (thisArg, _arguments, P, generator) {
@@ -133,17 +148,303 @@ var __generator =
     }
   };
 exports.__esModule = true;
-var execa_1 = require('execa');
-function buildExecutor(options) {
+exports.LARGE_BUFFER = void 0;
+var child_process_1 = require('child_process');
+var path = require('path');
+var yargsParser = require('yargs-parser');
+var npm_run_path_1 = require('npm-run-path');
+exports.LARGE_BUFFER = 1024 * 1000000;
+function loadEnvVars(path) {
   return __awaiter(this, void 0, void 0, function () {
-    return __generator(this, function (_a) {
-      console.info('Executing workspace:run-command...');
-      (0, execa_1.commandSync)(options.command, {
-        cwd: options.cwd,
-        stdio: [process.stdin, process.stdout, 'pipe'],
-      });
-      return [2 /*return*/, { success: true }];
+    var result, _a;
+    return __generator(this, function (_b) {
+      switch (_b.label) {
+        case 0:
+          if (!path) return [3 /*break*/, 2];
+          return [
+            4 /*yield*/,
+            Promise.resolve().then(function () {
+              return require('dotenv');
+            }),
+          ];
+        case 1:
+          result = _b.sent().config({ path: path });
+          if (result.error) {
+            throw result.error;
+          }
+          return [3 /*break*/, 5];
+        case 2:
+          _b.trys.push([2, 4, , 5]);
+          return [
+            4 /*yield*/,
+            Promise.resolve().then(function () {
+              return require('dotenv');
+            }),
+          ];
+        case 3:
+          _b.sent().config();
+          return [3 /*break*/, 5];
+        case 4:
+          _a = _b.sent();
+          return [3 /*break*/, 5];
+        case 5:
+          return [2 /*return*/];
+      }
     });
   });
 }
-exports['default'] = buildExecutor;
+var propKeys = [
+  'command',
+  'commands',
+  'color',
+  'parallel',
+  'readyWhen',
+  'cwd',
+  'args',
+  'envFile',
+  'outputPath',
+];
+function default_1(options, context) {
+  return __awaiter(this, void 0, void 0, function () {
+    var normalized, success, _a, e_1;
+    return __generator(this, function (_b) {
+      switch (_b.label) {
+        case 0:
+          return [4 /*yield*/, loadEnvVars(options.envFile)];
+        case 1:
+          _b.sent();
+          normalized = normalizeOptions(options);
+          if (options.readyWhen && !options.parallel) {
+            throw new Error(
+              'ERROR: Bad executor config for @nrwl/run-commands - "readyWhen" can only be used when "parallel=true".'
+            );
+          }
+          _b.label = 2;
+        case 2:
+          _b.trys.push([2, 7, , 8]);
+          if (!options.parallel) return [3 /*break*/, 4];
+          return [4 /*yield*/, runInParallel(normalized, context)];
+        case 3:
+          _a = _b.sent();
+          return [3 /*break*/, 6];
+        case 4:
+          return [4 /*yield*/, runSerially(normalized, context)];
+        case 5:
+          _a = _b.sent();
+          _b.label = 6;
+        case 6:
+          success = _a;
+          return [2 /*return*/, { success: success }];
+        case 7:
+          e_1 = _b.sent();
+          if (process.env.NX_VERBOSE_LOGGING === 'true') {
+            console.error(e_1);
+          }
+          throw new Error(
+            'ERROR: Something went wrong in @nrwl/run-commands - '.concat(
+              e_1.message
+            )
+          );
+        case 8:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+exports['default'] = default_1;
+function runInParallel(options, context) {
+  return __awaiter(this, void 0, void 0, function () {
+    var procs, r, r, failed;
+    return __generator(this, function (_a) {
+      switch (_a.label) {
+        case 0:
+          procs = options.commands.map(function (c) {
+            return createProcess(
+              c.command,
+              options.readyWhen,
+              options.color,
+              calculateCwd(options.cwd, context)
+            ).then(function (result) {
+              return {
+                result: result,
+                command: c.command,
+              };
+            });
+          });
+          if (!options.readyWhen) return [3 /*break*/, 2];
+          return [4 /*yield*/, Promise.race(procs)];
+        case 1:
+          r = _a.sent();
+          if (!r.result) {
+            process.stderr.write(
+              'Warning: @nrwl/run-commands command "'.concat(
+                r.command,
+                '" exited with non-zero status code'
+              )
+            );
+            return [2 /*return*/, false];
+          } else {
+            return [2 /*return*/, true];
+          }
+          return [3 /*break*/, 4];
+        case 2:
+          return [4 /*yield*/, Promise.all(procs)];
+        case 3:
+          r = _a.sent();
+          failed = r.filter(function (v) {
+            return !v.result;
+          });
+          if (failed.length > 0) {
+            failed.forEach(function (f) {
+              process.stderr.write(
+                'Warning: @nrwl/run-commands command "'.concat(
+                  f.command,
+                  '" exited with non-zero status code'
+                )
+              );
+            });
+            return [2 /*return*/, false];
+          } else {
+            return [2 /*return*/, true];
+          }
+          _a.label = 4;
+        case 4:
+          return [2 /*return*/];
+      }
+    });
+  });
+}
+function normalizeOptions(options) {
+  options.parsedArgs = parseArgs(options);
+  if (options.command) {
+    options.commands = [{ command: options.command }];
+    options.parallel = !!options.readyWhen;
+  } else {
+    options.commands = options.commands.map(function (c) {
+      return typeof c === 'string' ? { command: c } : c;
+    });
+  }
+  options.commands.forEach(function (c) {
+    var _a;
+    c.command = transformCommand(
+      c.command,
+      options.parsedArgs,
+      (_a = c.forwardAllArgs) !== null && _a !== void 0 ? _a : true
+    );
+  });
+  return options;
+}
+function runSerially(options, context) {
+  return __awaiter(this, void 0, void 0, function () {
+    var _i, _a, c;
+    return __generator(this, function (_b) {
+      for (_i = 0, _a = options.commands; _i < _a.length; _i++) {
+        c = _a[_i];
+        createSyncProcess(
+          c.command,
+          options.color,
+          calculateCwd(options.cwd, context)
+        );
+      }
+      return [2 /*return*/, true];
+    });
+  });
+}
+function createProcess(command, readyWhen, color, cwd) {
+  return new Promise(function (res) {
+    var childProcess = (0, child_process_1.exec)(command, {
+      maxBuffer: exports.LARGE_BUFFER,
+      env: processEnv(color),
+      cwd: cwd,
+    });
+    /**
+     * Ensure the child process is killed when the parent exits
+     */
+    var processExitListener = function () {
+      return childProcess.kill();
+    };
+    process.on('exit', processExitListener);
+    process.on('SIGTERM', processExitListener);
+    childProcess.stdout.on('data', function (data) {
+      process.stdout.write(data);
+      if (readyWhen && data.toString().indexOf(readyWhen) > -1) {
+        res(true);
+      }
+    });
+    childProcess.stderr.on('data', function (err) {
+      process.stderr.write(err);
+      if (readyWhen && err.toString().indexOf(readyWhen) > -1) {
+        res(true);
+      }
+    });
+    childProcess.on('exit', function (code) {
+      if (!readyWhen) {
+        res(code === 0);
+      }
+    });
+  });
+}
+function createSyncProcess(command, color, cwd) {
+  (0, child_process_1.execSync)(command, {
+    env: processEnv(color),
+    stdio: [process.stdin, process.stdout, 'pipe'],
+    maxBuffer: exports.LARGE_BUFFER,
+    cwd: cwd,
+  });
+}
+function calculateCwd(cwd, context) {
+  if (!cwd) return context.root;
+  if (path.isAbsolute(cwd)) return cwd;
+  return path.join(context.root, cwd);
+}
+function processEnv(color) {
+  var env = __assign(__assign({}, process.env), (0, npm_run_path_1.env)());
+  if (color) {
+    env.FORCE_COLOR = ''.concat(color);
+  }
+  return env;
+}
+function transformCommand(command, args, forwardAllArgs) {
+  if (command.indexOf('{args.') > -1) {
+    var regex = /{args\.([^}]+)}/g;
+    return command.replace(regex, function (_, group) {
+      return args[camelCase(group)];
+    });
+  } else if (Object.keys(args).length > 0 && forwardAllArgs) {
+    var stringifiedArgs = Object.keys(args)
+      .map(function (a) {
+        return typeof args[a] === 'string' && args[a].includes(' ')
+          ? '--'.concat(a, '="').concat(args[a].replace(/"/g, '"'), '"')
+          : '--'.concat(a, '=').concat(args[a]);
+      })
+      .join(' ');
+    return ''.concat(command, ' ').concat(stringifiedArgs);
+  } else {
+    return command;
+  }
+}
+function parseArgs(options) {
+  var args = options.args;
+  if (!args) {
+    var unknownOptionsTreatedAsArgs = Object.keys(options)
+      .filter(function (p) {
+        return propKeys.indexOf(p) === -1;
+      })
+      .reduce(function (m, c) {
+        return (m[c] = options[c]), m;
+      }, {});
+    return unknownOptionsTreatedAsArgs;
+  }
+  return yargsParser(args.replace(/(^"|"$)/g, ''), {
+    configuration: { 'camel-case-expansion': true },
+  });
+}
+function camelCase(input) {
+  if (input.indexOf('-') > 1) {
+    return input.toLowerCase().replace(/-(.)/g, function (match, group1) {
+      return group1.toUpperCase();
+    });
+  } else {
+    return input;
+  }
+}

--- a/tools/executors/workspace/impl.js
+++ b/tools/executors/workspace/impl.js
@@ -1,0 +1,149 @@
+'use strict';
+var __awaiter =
+  (this && this.__awaiter) ||
+  function (thisArg, _arguments, P, generator) {
+    function adopt(value) {
+      return value instanceof P
+        ? value
+        : new P(function (resolve) {
+            resolve(value);
+          });
+    }
+    return new (P || (P = Promise))(function (resolve, reject) {
+      function fulfilled(value) {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function rejected(value) {
+        try {
+          step(generator['throw'](value));
+        } catch (e) {
+          reject(e);
+        }
+      }
+      function step(result) {
+        result.done
+          ? resolve(result.value)
+          : adopt(result.value).then(fulfilled, rejected);
+      }
+      step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+  };
+var __generator =
+  (this && this.__generator) ||
+  function (thisArg, body) {
+    var _ = {
+        label: 0,
+        sent: function () {
+          if (t[0] & 1) throw t[1];
+          return t[1];
+        },
+        trys: [],
+        ops: [],
+      },
+      f,
+      y,
+      t,
+      g;
+    return (
+      (g = { next: verb(0), throw: verb(1), return: verb(2) }),
+      typeof Symbol === 'function' &&
+        (g[Symbol.iterator] = function () {
+          return this;
+        }),
+      g
+    );
+    function verb(n) {
+      return function (v) {
+        return step([n, v]);
+      };
+    }
+    function step(op) {
+      if (f) throw new TypeError('Generator is already executing.');
+      while (_)
+        try {
+          if (
+            ((f = 1),
+            y &&
+              (t =
+                op[0] & 2
+                  ? y['return']
+                  : op[0]
+                  ? y['throw'] || ((t = y['return']) && t.call(y), 0)
+                  : y.next) &&
+              !(t = t.call(y, op[1])).done)
+          )
+            return t;
+          if (((y = 0), t)) op = [op[0] & 2, t.value];
+          switch (op[0]) {
+            case 0:
+            case 1:
+              t = op;
+              break;
+            case 4:
+              _.label++;
+              return { value: op[1], done: false };
+            case 5:
+              _.label++;
+              y = op[1];
+              op = [0];
+              continue;
+            case 7:
+              op = _.ops.pop();
+              _.trys.pop();
+              continue;
+            default:
+              if (
+                !((t = _.trys), (t = t.length > 0 && t[t.length - 1])) &&
+                (op[0] === 6 || op[0] === 2)
+              ) {
+                _ = 0;
+                continue;
+              }
+              if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) {
+                _.label = op[1];
+                break;
+              }
+              if (op[0] === 6 && _.label < t[1]) {
+                _.label = t[1];
+                t = op;
+                break;
+              }
+              if (t && _.label < t[2]) {
+                _.label = t[2];
+                _.ops.push(op);
+                break;
+              }
+              if (t[2]) _.ops.pop();
+              _.trys.pop();
+              continue;
+          }
+          op = body.call(thisArg, _);
+        } catch (e) {
+          op = [6, e];
+          y = 0;
+        } finally {
+          f = t = 0;
+        }
+      if (op[0] & 5) throw op[1];
+      return { value: op[0] ? op[1] : void 0, done: true };
+    }
+  };
+exports.__esModule = true;
+var execa_1 = require('execa');
+function buildExecutor(options) {
+  return __awaiter(this, void 0, void 0, function () {
+    return __generator(this, function (_a) {
+      console.info('Executing workspace:run-command...');
+      (0, execa_1.commandSync)(options.command, {
+        cwd: options.cwd,
+        stdio: [process.stdin, process.stdout, 'pipe'],
+      });
+      return [2 /*return*/, { success: true }];
+    });
+  });
+}
+exports['default'] = buildExecutor;

--- a/tools/executors/workspace/impl.ts
+++ b/tools/executors/workspace/impl.ts
@@ -1,15 +1,285 @@
-import { commandSync } from 'execa';
+import { ExecutorContext } from '@nrwl/devkit';
+import { exec, execSync } from 'child_process';
+import * as path from 'path';
+import * as yargsParser from 'yargs-parser';
+import { env as appendLocalEnv } from 'npm-run-path';
 
-export default async function buildExecutor(options: {
-  command: string;
+export const LARGE_BUFFER = 1024 * 1000000;
+
+async function loadEnvVars(path?: string) {
+  if (path) {
+    const result = (await import('dotenv')).config({ path });
+    if (result.error) {
+      throw result.error;
+    }
+  } else {
+    try {
+      (await import('dotenv')).config();
+    } catch {}
+  }
+}
+
+export type Json = { [k: string]: any };
+export interface RunCommandsBuilderOptions extends Json {
+  command?: string;
+  commands?: (
+    | {
+        command: string;
+        forwardAllArgs?: boolean;
+        /**
+         * description was added to allow users to document their commands inline,
+         * it is not intended to be used as part of the execution of the command.
+         */
+        description?: string;
+      }
+    | string
+  )[];
+  color?: boolean;
+  parallel?: boolean;
+  readyWhen?: string;
   cwd?: string;
-}) {
-  console.info(`Executing workspace:run-command...`);
+  args?: string;
+  envFile?: string;
+  outputPath?: string;
+}
 
-  commandSync(options.command, {
-    cwd: options.cwd,
-    stdio: [process.stdin, process.stdout, 'pipe'],
+const propKeys = [
+  'command',
+  'commands',
+  'color',
+  'parallel',
+  'readyWhen',
+  'cwd',
+  'args',
+  'envFile',
+  'outputPath',
+];
+
+export interface NormalizedRunCommandsBuilderOptions
+  extends RunCommandsBuilderOptions {
+  commands: {
+    command: string;
+    forwardAllArgs?: boolean;
+  }[];
+  parsedArgs: { [k: string]: any };
+}
+
+export default async function (
+  options: RunCommandsBuilderOptions,
+  context: ExecutorContext
+): Promise<{ success: boolean }> {
+  await loadEnvVars(options.envFile);
+  const normalized = normalizeOptions(options);
+
+  if (options.readyWhen && !options.parallel) {
+    throw new Error(
+      'ERROR: Bad executor config for @nrwl/run-commands - "readyWhen" can only be used when "parallel=true".'
+    );
+  }
+
+  try {
+    const success = options.parallel
+      ? await runInParallel(normalized, context)
+      : await runSerially(normalized, context);
+    return { success };
+  } catch (e) {
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      console.error(e);
+    }
+    throw new Error(
+      `ERROR: Something went wrong in @nrwl/run-commands - ${e.message}`
+    );
+  }
+}
+
+async function runInParallel(
+  options: NormalizedRunCommandsBuilderOptions,
+  context: ExecutorContext
+) {
+  const procs = options.commands.map((c) =>
+    createProcess(
+      c.command,
+      options.readyWhen,
+      options.color,
+      calculateCwd(options.cwd, context)
+    ).then((result) => ({
+      result,
+      command: c.command,
+    }))
+  );
+
+  if (options.readyWhen) {
+    const r = await Promise.race(procs);
+    if (!r.result) {
+      process.stderr.write(
+        `Warning: @nrwl/run-commands command "${r.command}" exited with non-zero status code`
+      );
+      return false;
+    } else {
+      return true;
+    }
+  } else {
+    const r = await Promise.all(procs);
+    const failed = r.filter((v) => !v.result);
+    if (failed.length > 0) {
+      failed.forEach((f) => {
+        process.stderr.write(
+          `Warning: @nrwl/run-commands command "${f.command}" exited with non-zero status code`
+        );
+      });
+      return false;
+    } else {
+      return true;
+    }
+  }
+}
+
+function normalizeOptions(
+  options: RunCommandsBuilderOptions
+): NormalizedRunCommandsBuilderOptions {
+  options.parsedArgs = parseArgs(options);
+
+  if (options.command) {
+    options.commands = [{ command: options.command }];
+    options.parallel = !!options.readyWhen;
+  } else {
+    options.commands = options.commands.map((c) =>
+      typeof c === 'string' ? { command: c } : c
+    );
+  }
+  (options as NormalizedRunCommandsBuilderOptions).commands.forEach((c) => {
+    c.command = transformCommand(
+      c.command,
+      (options as NormalizedRunCommandsBuilderOptions).parsedArgs,
+      c.forwardAllArgs ?? true
+    );
   });
+  return options as any;
+}
 
-  return { success: true };
+async function runSerially(
+  options: NormalizedRunCommandsBuilderOptions,
+  context: ExecutorContext
+) {
+  for (const c of options.commands) {
+    createSyncProcess(
+      c.command,
+      options.color,
+      calculateCwd(options.cwd, context)
+    );
+  }
+  return true;
+}
+
+function createProcess(
+  command: string,
+  readyWhen: string,
+  color: boolean,
+  cwd: string
+): Promise<boolean> {
+  return new Promise((res) => {
+    const childProcess = exec(command, {
+      maxBuffer: LARGE_BUFFER,
+      env: processEnv(color),
+      cwd,
+    });
+    /**
+     * Ensure the child process is killed when the parent exits
+     */
+    const processExitListener = () => childProcess.kill();
+    process.on('exit', processExitListener);
+    process.on('SIGTERM', processExitListener);
+    childProcess.stdout.on('data', (data) => {
+      process.stdout.write(data);
+      if (readyWhen && data.toString().indexOf(readyWhen) > -1) {
+        res(true);
+      }
+    });
+    childProcess.stderr.on('data', (err) => {
+      process.stderr.write(err);
+      if (readyWhen && err.toString().indexOf(readyWhen) > -1) {
+        res(true);
+      }
+    });
+    childProcess.on('exit', (code) => {
+      if (!readyWhen) {
+        res(code === 0);
+      }
+    });
+  });
+}
+
+function createSyncProcess(command: string, color: boolean, cwd: string) {
+  execSync(command, {
+    env: processEnv(color),
+    stdio: [process.stdin, process.stdout, 'pipe'],
+    maxBuffer: LARGE_BUFFER,
+    cwd,
+  });
+}
+
+function calculateCwd(
+  cwd: string | undefined,
+  context: ExecutorContext
+): string {
+  if (!cwd) return context.root;
+  if (path.isAbsolute(cwd)) return cwd;
+  return path.join(context.root, cwd);
+}
+
+function processEnv(color: boolean) {
+  const env = {
+    ...process.env,
+    ...appendLocalEnv(),
+  };
+
+  if (color) {
+    env.FORCE_COLOR = `${color}`;
+  }
+  return env;
+}
+
+function transformCommand(
+  command: string,
+  args: { [key: string]: string },
+  forwardAllArgs: boolean
+) {
+  if (command.indexOf('{args.') > -1) {
+    const regex = /{args\.([^}]+)}/g;
+    return command.replace(regex, (_, group: string) => args[camelCase(group)]);
+  } else if (Object.keys(args).length > 0 && forwardAllArgs) {
+    const stringifiedArgs = Object.keys(args)
+      .map((a) =>
+        typeof args[a] === 'string' && args[a].includes(' ')
+          ? `--${a}="${args[a].replace(/"/g, '"')}"`
+          : `--${a}=${args[a]}`
+      )
+      .join(' ');
+    return `${command} ${stringifiedArgs}`;
+  } else {
+    return command;
+  }
+}
+
+function parseArgs(options: RunCommandsBuilderOptions) {
+  const args = options.args;
+  if (!args) {
+    const unknownOptionsTreatedAsArgs = Object.keys(options)
+      .filter((p) => propKeys.indexOf(p) === -1)
+      .reduce((m, c) => ((m[c] = options[c]), m), {});
+    return unknownOptionsTreatedAsArgs;
+  }
+  return yargsParser(args.replace(/(^"|"$)/g, ''), {
+    configuration: { 'camel-case-expansion': true },
+  });
+}
+
+function camelCase(input) {
+  if (input.indexOf('-') > 1) {
+    return input
+      .toLowerCase()
+      .replace(/-(.)/g, (match, group1) => group1.toUpperCase());
+  } else {
+    return input;
+  }
 }

--- a/tools/executors/workspace/impl.ts
+++ b/tools/executors/workspace/impl.ts
@@ -1,0 +1,15 @@
+import { commandSync } from 'execa';
+
+export default async function buildExecutor(options: {
+  command: string;
+  cwd?: string;
+}) {
+  console.info(`Executing workspace:run-command...`);
+
+  commandSync(options.command, {
+    cwd: options.cwd,
+    stdio: [process.stdin, process.stdout, 'pipe'],
+  });
+
+  return { success: true };
+}

--- a/tools/executors/workspace/package.json
+++ b/tools/executors/workspace/package.json
@@ -1,0 +1,3 @@
+{
+  "executors": "./executor.json"
+}

--- a/tools/executors/workspace/schema.json
+++ b/tools/executors/workspace/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "cli": "nx",
+  "properties": {
+    "command": {
+      "type": "string",
+      "description": "The command to run"
+    },
+    "cwd": {
+      "type": "string",
+      "description": "The working directory to run the command in"
+    }
+  },
+  "required": ["command"]
+}

--- a/tools/generators/lib/files/console.js
+++ b/tools/generators/lib/files/console.js
@@ -1,0 +1,34 @@
+// const fs = require('fs');
+const path = require('path');
+const repl = require('repl');
+const shared = require(path.join(__dirname, 'src'));
+
+const loadFunctions = (context) => {
+  Object.keys(require.cache).forEach((key) => {
+    delete require.cache[key];
+  });
+
+  Object.entries(shared).forEach(([key, value]) => {
+    context[key] = value;
+  });
+
+  // fs.readdirSync(modelDir, 'utf8').forEach((name) => {
+  //   const filePath = path.join(modelDir, name);
+  //   context[name.slice(0, -3)] = require(filePath);
+  // });
+};
+
+const replServer = repl.start('app > ');
+replServer.setupHistory('./.node_repl_history', (err) => {
+  console.error(err);
+});
+loadFunctions(replServer.context);
+
+replServer.defineCommand('re', {
+  help: 'Reload the models without resetting the environment',
+  action() {
+    loadFunctions(replServer.context);
+    console.log('reloaded!');
+    this.displayPrompt();
+  },
+});

--- a/tools/generators/lib/index.ts
+++ b/tools/generators/lib/index.ts
@@ -1,0 +1,10 @@
+import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
+import { libraryGenerator } from '@nrwl/workspace/generators';
+
+export default async function (tree: Tree, schema: any) {
+  await libraryGenerator(tree, { name: schema.name });
+  await formatFiles(tree);
+  return () => {
+    installPackagesTask(tree);
+  };
+}

--- a/tools/generators/lib/index.ts
+++ b/tools/generators/lib/index.ts
@@ -5,10 +5,16 @@ import {
   readProjectConfiguration,
   generateFiles,
   joinPathFragments,
+  getWorkspaceLayout,
+  updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/workspace/generators';
 
-export default async function (tree: Tree, schema: any) {
+type Schema = {
+  readonly name: string;
+};
+
+export default async function (tree: Tree, schema: Schema) {
   await libraryGenerator(tree, { name: schema.name });
   const libraryRoot = readProjectConfiguration(tree, schema.name).root;
 
@@ -19,8 +25,28 @@ export default async function (tree: Tree, schema: any) {
     schema
   );
 
+  updateProject(tree, schema);
+
   await formatFiles(tree);
   return () => {
     installPackagesTask(tree);
   };
+}
+
+// See https://github.com/nrwl/nx/blob/efedd2eff78700a72bcc30bdf7450656860a4ffb/packages/node/src/generators/library/library.ts#L130-L156
+function updateProject(tree: Tree, options: Schema) {
+  const project = readProjectConfiguration(tree, options.name);
+
+  project.targets = project.targets || {};
+  project.targets.console = {
+    executor: './tools/executors/workspace:run-command',
+    options: {
+      cwd: 'libs/shared',
+      color: true,
+      command:
+        'node --experimental-repl-await -r ts-node/register ./console.js',
+    },
+  };
+
+  updateProjectConfiguration(tree, options.name, project);
 }

--- a/tools/generators/lib/index.ts
+++ b/tools/generators/lib/index.ts
@@ -1,8 +1,24 @@
-import { Tree, formatFiles, installPackagesTask } from '@nrwl/devkit';
+import {
+  Tree,
+  formatFiles,
+  installPackagesTask,
+  readProjectConfiguration,
+  generateFiles,
+  joinPathFragments,
+} from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/workspace/generators';
 
 export default async function (tree: Tree, schema: any) {
   await libraryGenerator(tree, { name: schema.name });
+  const libraryRoot = readProjectConfiguration(tree, schema.name).root;
+
+  generateFiles(
+    tree,
+    joinPathFragments(__dirname, './files'),
+    libraryRoot,
+    schema
+  );
+
   await formatFiles(tree);
   return () => {
     installPackagesTask(tree);

--- a/tools/generators/lib/schema.json
+++ b/tools/generators/lib/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "lib",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    }
+  },
+  "required": ["name"]
+}

--- a/tools/generators/service/workspace-config.ts
+++ b/tools/generators/service/workspace-config.ts
@@ -1,7 +1,7 @@
 import { addProjectConfiguration, Tree } from '@nrwl/devkit';
 
 const buildRunCommandConfig = (dir: string, command: string) => ({
-  executor: '@nrwl/workspace:run-commands',
+  executor: './tools/executors/workspace:run-command',
   options: {
     cwd: dir,
     color: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,6 +593,18 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz#eea4635828dde372838b0909693ebd9aafeec22d"
@@ -2032,6 +2044,26 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -2637,6 +2669,11 @@ acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^7.1.1:
   version "7.4.1"
@@ -4879,7 +4916,7 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@^5.0.0, execa@^5.1.1:
+execa@5.1.1, execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -9741,6 +9778,25 @@ ts-log@^2.2.3:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.4.tgz#d672cf904b33735eaba67a7395c93d45fba475b3"
   integrity sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ==
 
+ts-node@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.5.0.tgz#618bef5854c1fbbedf5e31465cbb224a1d524ef9"
+  integrity sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.0"
+    yn "3.1.1"
+
 ts-node@^9, ts-node@~9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
@@ -9997,6 +10053,11 @@ uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
+  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
 
 v8-compile-cache@2.3.0, v8-compile-cache@^2.0.3:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4916,7 +4916,7 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@5.1.1, execa@^5.0.0, execa@^5.1.1:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
- add custom executor for run-commands
  - allows console to be interactive
  - fixes bug when running `serve` that broke serverless-offline output
- add custom console script for repl
- add `lib` generator that includes console

console README:
- Run `yarn console <SERVICE/LIBRARY_NAME>` to start the console
- Any files in `src/index` for that service/lib will be auto-loaded into the repl's context
- If you make a change to a file, you can reset the console using `.re` in the repl which will reload all the files
- **IMPORTANT NOTE**: There is a known issue with node's `require` being slow (~700ms per require). This means the more files you include in your modules `src/index`, the longer it will take for the console to load/reload. Please keep this in mind when developing using this feature. This will also use your `.env` so if you have database connections you're testing, these will be **live/hot/real** so proceed with _extreme_ caution.

Closes #4 
